### PR TITLE
add support for unsaved buffers

### DIFF
--- a/DenizenLangServer/DiagnosticProvider.cs
+++ b/DenizenLangServer/DiagnosticProvider.cs
@@ -53,7 +53,7 @@ namespace DenizenLangServer
                     needsUpdate = NeedsNewDiag;
                     NeedsNewDiag = false;
                     loops++;
-                    if (loops > 60 && DiagDoc != null && DiagDoc.Uri.AbsolutePath.EndsWith(".dsc"))
+                    if (loops > 60 && DiagDoc != null && (DiagDoc.Uri.AbsolutePath.EndsWith(".dsc") || DiagDoc.Uri.Scheme == "untitled"))
                     {
                         loops = 0;
                         needsUpdate = true;
@@ -131,7 +131,7 @@ namespace DenizenLangServer
             {
                 checker.Run();
                 PublishCheckerResults(document.Uri, checker);
-                WorkspaceTracker.Replace(document.Uri, checker);
+                WorkspaceTracker.Replace(document.Uri, checker, document.Content);
             }
             catch (Exception ex)
             {

--- a/DenizenLangServer/DiagnosticProvider.cs
+++ b/DenizenLangServer/DiagnosticProvider.cs
@@ -53,7 +53,7 @@ namespace DenizenLangServer
                     needsUpdate = NeedsNewDiag;
                     NeedsNewDiag = false;
                     loops++;
-                    if (loops > 60 && DiagDoc != null && (DiagDoc.Uri.AbsolutePath.EndsWith(".dsc") || DiagDoc.Uri.Scheme == "untitled"))
+                    if (loops > 60 && DiagDoc != null && WorkspaceTracker.IsDenizenDocument(DiagDoc.Uri))
                     {
                         loops = 0;
                         needsUpdate = true;

--- a/DenizenLangServer/Services/TextDocumentService.cs
+++ b/DenizenLangServer/Services/TextDocumentService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -34,7 +34,7 @@ namespace DenizenLangServer.Services
             }
             // TODO: All this code is a dirty "it works" vertical slice mess that needs to be cleaned up
             TextDocument doc = GetDocument(textDocument);
-            if (doc == null || !textDocument.Uri.AbsolutePath.EndsWith(".dsc"))
+            if (doc == null || !(textDocument.Uri.AbsolutePath.EndsWith(".dsc") || textDocument.Uri.Scheme == "untitled"))
             {
                 return null;
             }
@@ -272,7 +272,7 @@ namespace DenizenLangServer.Services
                     return null;
                 }
                 TextDocument doc = GetDocument(textDocument);
-                if (doc == null || !textDocument.Uri.AbsolutePath.EndsWith(".dsc"))
+                if (doc == null || !(textDocument.Uri.AbsolutePath.EndsWith(".dsc") || textDocument.Uri.Scheme == "untitled"))
                 {
                     return new CompletionList(EmptyCompletionItems);
                 }

--- a/DenizenLangServer/Services/TextDocumentService.cs
+++ b/DenizenLangServer/Services/TextDocumentService.cs
@@ -34,7 +34,7 @@ namespace DenizenLangServer.Services
             }
             // TODO: All this code is a dirty "it works" vertical slice mess that needs to be cleaned up
             TextDocument doc = GetDocument(textDocument);
-            if (doc == null || !(textDocument.Uri.AbsolutePath.EndsWith(".dsc") || textDocument.Uri.Scheme == "untitled"))
+            if (doc == null || !WorkspaceTracker.IsDenizenDocument(textDocument.Uri))
             {
                 return null;
             }
@@ -272,7 +272,7 @@ namespace DenizenLangServer.Services
                     return null;
                 }
                 TextDocument doc = GetDocument(textDocument);
-                if (doc == null || !(textDocument.Uri.AbsolutePath.EndsWith(".dsc") || textDocument.Uri.Scheme == "untitled"))
+                if (doc == null || !WorkspaceTracker.IsDenizenDocument(textDocument.Uri))
                 {
                     return new CompletionList(EmptyCompletionItems);
                 }

--- a/DenizenLangServer/Services/TextDocumentService.cs
+++ b/DenizenLangServer/Services/TextDocumentService.cs
@@ -256,6 +256,7 @@ namespace DenizenLangServer.Services
         public void DidClose(TextDocumentIdentifier textDocument)
         {
             Session.Documents.TryRemove(textDocument.Uri, out _);
+            WorkspaceTracker.UntitledPayloads.TryRemove(WorkspaceTracker.FixPath(textDocument.Uri), out _);
         }
 
         private static readonly CompletionItem[] EmptyCompletionItems = [];

--- a/DenizenLangServer/WorkspaceTracker.cs
+++ b/DenizenLangServer/WorkspaceTracker.cs
@@ -1,4 +1,4 @@
-﻿using FreneticUtilities.FreneticExtensions;
+using FreneticUtilities.FreneticExtensions;
 using FreneticUtilities.FreneticToolkit;
 using SharpDenizenTools.ScriptAnalysis;
 using System;
@@ -14,6 +14,8 @@ namespace DenizenLangServer
     public static class WorkspaceTracker
     {
         public static ConcurrentDictionary<string, ScriptChecker> Checkers = new();
+
+        public static ConcurrentDictionary<string, string> UntitledPayloads = new();
 
         public static volatile ScriptingWorkspaceData WorkspaceData = null;
 
@@ -37,11 +39,15 @@ namespace DenizenLangServer
             Checkers[FixPath(file)] = checker;
         }
 
-        public static void Replace(Uri file, ScriptChecker checker)
+        public static void Replace(Uri file, ScriptChecker checker, string content = null)
         {
             if (!ClientConfiguration.TrackFullWorkspace || WorkspacePath is null)
             {
                 return;
+            }
+            if (file.Scheme == "untitled" && content != null)
+            {
+                UntitledPayloads[FixPath(file)] = content;
             }
             AddInternal(file, checker);
             long index = ++LastUpdate;
@@ -55,6 +61,10 @@ namespace DenizenLangServer
             if (uri is null)
             {
                 return null;
+            }
+            if (uri.Scheme == "untitled")
+            {
+                return uri.ToString();
             }
             string path = uri.ToString()["file://".Length..];
             // Microsoft always puts a preceding '/' on their corrupt escaped URIs.
@@ -77,6 +87,10 @@ namespace DenizenLangServer
 
         public static Uri PathToUri(string path)
         {
+            if (path.StartsWith("untitled:"))
+            {
+                return new(path);
+            }
             if (path[0..3].Contains(':'))
             {
                 path = $"/{Uri.EscapeDataString(path)}";
@@ -122,7 +136,8 @@ namespace DenizenLangServer
                         }
                         foreach ((string path, _) in copyCheckers)
                         {
-                            ScriptChecker checker = new(File.ReadAllText(path))
+                            string text = UntitledPayloads.TryGetValue(path, out string payload) ? payload : File.ReadAllText(path);
+                            ScriptChecker checker = new(text)
                             {
                                 SurroundingWorkspace = genData
                             };

--- a/DenizenLangServer/WorkspaceTracker.cs
+++ b/DenizenLangServer/WorkspaceTracker.cs
@@ -45,7 +45,7 @@ namespace DenizenLangServer
             {
                 return;
             }
-            if (file.Scheme == "untitled" && content != null)
+            if (file.Scheme == "untitled" && content is not null)
             {
                 UntitledPayloads[FixPath(file)] = content;
             }

--- a/DenizenLangServer/WorkspaceTracker.cs
+++ b/DenizenLangServer/WorkspaceTracker.cs
@@ -56,6 +56,15 @@ namespace DenizenLangServer
 
         private static bool HaveShownPath = false;
 
+        public static bool IsDenizenDocument(Uri uri)
+        {
+            if (uri is null)
+            {
+                return false;
+            }
+            return uri.AbsolutePath.EndsWith(".dsc") || uri.Scheme == "untitled";
+        }
+
         public static string FixPath(Uri uri)
         {
             if (uri is null)

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "denizenscript",
-    "version": "1.4.8",
+    "version": "1.4.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "denizenscript",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "license": "MIT",
             "dependencies": {
                 "vscode-languageclient": "^7.0.0"

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "denizenscript",
-    "version": "1.4.9",
+    "version": "1.4.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "denizenscript",
-            "version": "1.4.9",
+            "version": "1.4.8",
             "license": "MIT",
             "dependencies": {
                 "vscode-languageclient": "^7.0.0"

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -27,7 +27,7 @@ class HighlightCache {
 let HLCaches : Map<string, HighlightCache> = new Map<string, HighlightCache>();
 
 function getCache(path : string) {
-    let result : HighlightCache = HLCaches.get(path);
+    let result = HLCaches.get(path);
     if (result) {
         return result;
     }
@@ -50,7 +50,10 @@ function activateLanguageServer(context: vscode.ExtensionContext, dotnetPath : s
         debug: { command: dotnetPath, args: [pathFile, "--debug"], options: { cwd: pathDir } }
     }
     let clientOptions: languageClient.LanguageClientOptions = {
-        documentSelector: ["denizenscript"],
+        documentSelector: [
+            { scheme: 'file', language: 'denizenscript' },
+            { scheme: 'untitled', language: 'denizenscript' }
+        ],
         synchronize: {
             configurationSection: "denizenscript",
         },
@@ -118,19 +121,19 @@ const colorTypes : string[] = [
 function loadAllColors() {
     configuration = vscode.workspace.getConfiguration();
     for (const i in colorTypes) {
-        let str : string = configuration.get("denizenscript.theme_colors." + colorTypes[i]);
+        let str = configuration.get<string>("denizenscript.theme_colors." + colorTypes[i]);
         if (str === undefined) {
             outputChannel.appendLine("Missing color config for " + colorTypes[i]);
             continue;
         }
         colorSet(colorTypes[i], str);
     }
-    headerSymbols = configuration.get("denizenscript.header_symbols");
-    debugHighlighting = configuration.get("denizenscript.debug.highlighting");
-    debugFolding = configuration.get("denizenscript.debug.folding");
-    doInlineColors = configuration.get("denizenscript.behaviors.do_inline_colors");
-    displayDarkColors = configuration.get("denizenscript.behaviors.display_dark_colors");
-    const customColors : string = configuration.get("denizenscript.theme_colors.text_color_map");
+    headerSymbols = configuration.get<string>("denizenscript.header_symbols") ?? "";
+    debugHighlighting = configuration.get<boolean>("denizenscript.debug.highlighting") ?? false;
+    debugFolding = configuration.get<boolean>("denizenscript.debug.folding") ?? false;
+    doInlineColors = configuration.get<boolean>("denizenscript.behaviors.do_inline_colors") ?? false;
+    displayDarkColors = configuration.get<boolean>("denizenscript.behaviors.display_dark_colors") ?? false;
+    const customColors = configuration.get<string>("denizenscript.theme_colors.text_color_map") ?? "";
     const colorsSplit : string[] = customColors.split(',');
     for (const i in colorsSplit) {
         const color = colorsSplit[i];
@@ -153,8 +156,7 @@ let refreshTimer: NodeJS.Timer | undefined = undefined;
 function refreshDecor() {
     refreshTimer = undefined;
     for (const editor of vscode.window.visibleTextEditors) {
-        const uri = editor.document.uri.toString();
-        if (!uri.endsWith(".dsc")) {
+        if (editor.document.languageId !== 'denizenscript') {
             continue;
         }
         decorateFullFile(editor);
@@ -215,7 +217,7 @@ function decorateTag(tag : string, start: number, lineNumber: number, decoration
             inTagCounter--;
             if (inTagCounter == 0) {
                 const tagText : string = tag.substring(tagStart + 1, i);
-                let autoColor : string = getTagColor(tagText, textColor);
+                const autoColor = getTagColor(tagText, textColor);
                 if (autoColor != null) {
                     addDecor(decorations, "auto:" + autoColor, lineNumber, start + tagStart + 1, start + i);
                     addDecor(decorations, "tag", lineNumber, start + tagStart, start + tagStart + 1);
@@ -364,7 +366,7 @@ function isHex(text : string) : boolean {
     return true;
 }
 
-function getColorData(color : string) : string {
+function getColorData(color : string) : string | null {
     if (color.startsWith("#")) {
         return color;
     }
@@ -378,7 +380,7 @@ function getColorData(color : string) : string {
     return null;
 }
 
-function fixDark(color : string) {
+function fixDark(color : string) : string | null {
     if (color == null) {
         return null;
     }
@@ -399,7 +401,7 @@ function fixDark(color : string) {
     return color;
 }
 
-function getTagColor(tagText : string, preColor : string) : string {
+function getTagColor(tagText : string, preColor : string) : string | null {
     if (!doInlineColors) {
         return null;
     }
@@ -415,7 +417,7 @@ function getTagColor(tagText : string, preColor : string) : string {
     }
     const formatter : string = formatCodes[tagText];
     if (formatter) {
-        const rgb : string = getColorData(preColor);
+        const rgb = getColorData(preColor);
         if (rgb) {
             if (formatter == "bold") {
                 return rgb + "|weight=bold";
@@ -482,7 +484,7 @@ function decorateArg(arg : string, start: number, lineNumber: number, decoration
             inTagCounter--;
             if (inTagCounter == 0) {
                 const tagText : string = arg.substring(tagStart + 1, i);
-                let autoColor : string = getTagColor(tagText, textColor);
+                const autoColor = getTagColor(tagText, textColor);
                 if (autoColor != null) {
                     addDecor(decorations, "tag", lineNumber, start + tagStart, start + tagStart + 1);
                     addDecor(decorations, "auto:" + autoColor, lineNumber, start + tagStart + 1, start + i);
@@ -962,7 +964,7 @@ async function activateDotNet() {
     try {
         outputChannel.appendLine("DenizenScript extension attempting to acquire .NET 8");
         const requestingExtensionId = 'DenizenScript.denizenscript';
-        const result = await vscode.commands.executeCommand('dotnet.acquire', { version: '8.0', requestingExtensionId });
+        const result = await vscode.commands.executeCommand<any>('dotnet.acquire', { version: '8.0', requestingExtensionId });
         outputChannel.appendLine("DenizenScript extension NET 8 Acquire result: " + result + ": " + result["dotnetPath"]);
         return result["dotnetPath"];
     }
@@ -992,7 +994,7 @@ function applyConfigColors() {
         let color = "";
         if (val.startsWith("<") && val.endsWith(">")) {
             for (const tag of val.slice(1, -1).split("><")) {
-                const newColor : string = getTagColor(tag, color);
+                const newColor = getTagColor(tag, color);
                 if (newColor) {
                     color = newColor;
                 }
@@ -1061,14 +1063,14 @@ export async function activate(context: vscode.ExtensionContext) {
     activateLanguageServer(context, path);
     activateHighlighter(context);
     vscode.workspace.onDidOpenTextDocument(doc => {
-        if (doc.uri.toString().endsWith(".dsc")) {
+        if (doc.languageId === 'denizenscript') {
             tryLoadConfigYaml(doc);
             forceRefresh("onDidOpenTextDocument");
         }
     }, null, context.subscriptions);
     vscode.workspace.onDidChangeTextDocument(event => {
-        const curFile : string = event.document.uri.toString();
-        if (curFile.endsWith(".dsc")) {
+        if (event.document.languageId === 'denizenscript') {
+            const curFile = event.document.uri.toString();
             let highlight : HighlightCache = getCache(curFile);
             event.contentChanges.forEach(change => {
                 if (highlight.needRefreshStartLine == -1 || change.range.start.line < highlight.needRefreshStartLine) {
@@ -1091,8 +1093,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }, null, context.subscriptions);
     vscode.window.onDidChangeVisibleTextEditors(editors => {
         for (const editor of editors) {
-            const uri = editor.document.uri.toString();
-            if (!uri.endsWith(".dsc")) {
+            if (editor.document.languageId !== 'denizenscript') {
                 continue;
             }
             tryLoadConfigYaml(editor.document);

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -27,7 +27,7 @@ class HighlightCache {
 let HLCaches : Map<string, HighlightCache> = new Map<string, HighlightCache>();
 
 function getCache(path : string) {
-    let result = HLCaches.get(path);
+    let result : HighlightCache = HLCaches.get(path);
     if (result) {
         return result;
     }
@@ -121,19 +121,19 @@ const colorTypes : string[] = [
 function loadAllColors() {
     configuration = vscode.workspace.getConfiguration();
     for (const i in colorTypes) {
-        let str = configuration.get<string>("denizenscript.theme_colors." + colorTypes[i]);
+        let str : string = configuration.get("denizenscript.theme_colors." + colorTypes[i]);
         if (str === undefined) {
             outputChannel.appendLine("Missing color config for " + colorTypes[i]);
             continue;
         }
         colorSet(colorTypes[i], str);
     }
-    headerSymbols = configuration.get<string>("denizenscript.header_symbols") ?? "";
-    debugHighlighting = configuration.get<boolean>("denizenscript.debug.highlighting") ?? false;
-    debugFolding = configuration.get<boolean>("denizenscript.debug.folding") ?? false;
-    doInlineColors = configuration.get<boolean>("denizenscript.behaviors.do_inline_colors") ?? false;
-    displayDarkColors = configuration.get<boolean>("denizenscript.behaviors.display_dark_colors") ?? false;
-    const customColors = configuration.get<string>("denizenscript.theme_colors.text_color_map") ?? "";
+    headerSymbols = configuration.get("denizenscript.header_symbols");
+    debugHighlighting = configuration.get("denizenscript.debug.highlighting");
+    debugFolding = configuration.get("denizenscript.debug.folding");
+    doInlineColors = configuration.get("denizenscript.behaviors.do_inline_colors");
+    displayDarkColors = configuration.get("denizenscript.behaviors.display_dark_colors");
+    const customColors : string = configuration.get("denizenscript.theme_colors.text_color_map");
     const colorsSplit : string[] = customColors.split(',');
     for (const i in colorsSplit) {
         const color = colorsSplit[i];
@@ -217,7 +217,7 @@ function decorateTag(tag : string, start: number, lineNumber: number, decoration
             inTagCounter--;
             if (inTagCounter == 0) {
                 const tagText : string = tag.substring(tagStart + 1, i);
-                const autoColor = getTagColor(tagText, textColor);
+                let autoColor : string = getTagColor(tagText, textColor);
                 if (autoColor != null) {
                     addDecor(decorations, "auto:" + autoColor, lineNumber, start + tagStart + 1, start + i);
                     addDecor(decorations, "tag", lineNumber, start + tagStart, start + tagStart + 1);
@@ -366,7 +366,7 @@ function isHex(text : string) : boolean {
     return true;
 }
 
-function getColorData(color : string) : string | null {
+function getColorData(color : string) : string {
     if (color.startsWith("#")) {
         return color;
     }
@@ -380,7 +380,7 @@ function getColorData(color : string) : string | null {
     return null;
 }
 
-function fixDark(color : string) : string | null {
+function fixDark(color : string) {
     if (color == null) {
         return null;
     }
@@ -401,7 +401,7 @@ function fixDark(color : string) : string | null {
     return color;
 }
 
-function getTagColor(tagText : string, preColor : string) : string | null {
+function getTagColor(tagText : string, preColor : string) : string {
     if (!doInlineColors) {
         return null;
     }
@@ -417,7 +417,7 @@ function getTagColor(tagText : string, preColor : string) : string | null {
     }
     const formatter : string = formatCodes[tagText];
     if (formatter) {
-        const rgb = getColorData(preColor);
+        const rgb : string = getColorData(preColor);
         if (rgb) {
             if (formatter == "bold") {
                 return rgb + "|weight=bold";
@@ -484,7 +484,7 @@ function decorateArg(arg : string, start: number, lineNumber: number, decoration
             inTagCounter--;
             if (inTagCounter == 0) {
                 const tagText : string = arg.substring(tagStart + 1, i);
-                const autoColor = getTagColor(tagText, textColor);
+                let autoColor : string = getTagColor(tagText, textColor);
                 if (autoColor != null) {
                     addDecor(decorations, "tag", lineNumber, start + tagStart, start + tagStart + 1);
                     addDecor(decorations, "auto:" + autoColor, lineNumber, start + tagStart + 1, start + i);
@@ -964,7 +964,7 @@ async function activateDotNet() {
     try {
         outputChannel.appendLine("DenizenScript extension attempting to acquire .NET 8");
         const requestingExtensionId = 'DenizenScript.denizenscript';
-        const result = await vscode.commands.executeCommand<any>('dotnet.acquire', { version: '8.0', requestingExtensionId });
+        const result = await vscode.commands.executeCommand('dotnet.acquire', { version: '8.0', requestingExtensionId });
         outputChannel.appendLine("DenizenScript extension NET 8 Acquire result: " + result + ": " + result["dotnetPath"]);
         return result["dotnetPath"];
     }
@@ -994,7 +994,7 @@ function applyConfigColors() {
         let color = "";
         if (val.startsWith("<") && val.endsWith(">")) {
             for (const tag of val.slice(1, -1).split("><")) {
-                const newColor = getTagColor(tag, color);
+                const newColor : string = getTagColor(tag, color);
                 if (newColor) {
                     color = newColor;
                 }
@@ -1070,7 +1070,7 @@ export async function activate(context: vscode.ExtensionContext) {
     }, null, context.subscriptions);
     vscode.workspace.onDidChangeTextDocument(event => {
         if (event.document.languageId === 'denizenscript') {
-            const curFile = event.document.uri.toString();
+            const curFile : string = event.document.uri.toString();
             let highlight : HighlightCache = getCache(curFile);
             event.contentChanges.forEach(change => {
                 if (highlight.needRefreshStartLine == -1 || change.range.start.line < highlight.needRefreshStartLine) {


### PR DESCRIPTION
This pull request adds support for syntax highlighting/linting/autocomplete features in unsaved (`untitled`) files in VSCode; [relevant discord conversation](https://discord.com/channels/315163488085475337/1011496047811506227/1521745276543569931)

Currently, the extension explicitly filtered for physical `.dsc` files both on the client and server side; users can't use the extension in quick notepads without saving them to disk first.

### Frontend/TypeScript changes
- [x] updated the `documentSelector` for the client to explicitly include the missing/blank `{ scheme: 'untitled', language: 'denizenscript' }`
- [x] refactored various string-matching checks (like `.endsWith(".dsc")`) in `extension.ts` to instead rely on VSCode's built-in `document.languageId === 'denizenscript'`; this fixes the client's language auto detecting
- [x] reorganized configuration parsing

### Backend/C# Changes
I'm not very experienced with C#, but i made sure to consistently reference docs and guides;
- [x] added a static `WorkspaceTracker.IsDenizenDocument(Uri uri)` helper replacing repeated doc validation across the server
- [x] updated `TextDocumentService` and `DiagnosticProvider` to properly process docs with the `untitled` scheme that was missing
- [x] added an `UntitledPayloads` dictionary to `WorkspaceTracker`; since untitled files don't exist on disk, their text payload is now cached here when updated so the `ScriptChecker` can successfully read and lint them

### Testing
- [x] verified working by opening the extension in the extension development host:
![verified working example](https://cdn.discordapp.com/attachments/1011496047811506227/1521769338770559018/image.png?ex=6a4609a3&is=6a44b823&hm=9344e38cc486261a6e3b441c229329edc1d12d98087f15966c22be4f811787c2&)

> **Some side notes**;
> i changed the return types for `getColorData`, `fixDark`, and `getTagColor` because they returned strings; they actually returned `null` in a few cases and made the compilation console angry so i made it return `string | null` instead